### PR TITLE
Added TypeScript definition for lz-string module

### DIFF
--- a/typings/lz-string.d.ts
+++ b/typings/lz-string.d.ts
@@ -1,0 +1,16 @@
+declare module LZString {
+  function compressToBase64(input: string): string;
+  function decompressFromBase64(input: string): string;
+
+  function compressToUTF16(input: string): string;
+  function decompressFromUTF16(compressed: string): string;
+
+  function compressToUint8Array(uncompressed: string): Uint8Array;
+  function decompressFromUint8Array(compressed: Uint8Array): string;
+
+  function compressToEncodedURIComponent(input: string): string;
+  function decompressFromEncodedURIComponent(compressed: string): string;
+
+  function compress(input: string): string;
+  function decompress(compressed: string): string;
+}


### PR DESCRIPTION
Added a TypeScript definition file (*.d.ts) for the lz-string main library. The interface is pretty basic but provides IntelliSense support.

https://typescript.codeplex.com/wikipage?title=Writing%20Definition%20%28.d.ts%29%20Files